### PR TITLE
Fix Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,12 +10,13 @@ WriteMakefile(
     ABSTRACT_FROM    => 'lib/Sub/Fp.pm',
     LICENSE          => 'artistic_2',
     PL_FILES         => {},
-    MIN_PERL_VERSION => '5.006',
+    MIN_PERL_VERSION => '5.010',
     CONFIGURE_REQUIRES => {
         'ExtUtils::MakeMaker' => '0',
     },
     BUILD_REQUIRES => {
         'Test::More' => '0',
+        'Test::Class' => '0',
     },
     PREREQ_PM => {
         #'ABC'              => '1.6',


### PR DESCRIPTION
A build requirement (Test::Class) wasn't listed and a Perl >= 5.10 feature is used (defined-or "//").